### PR TITLE
Prevent instance-conflicting grouped field value records from showing stale data

### DIFF
--- a/plugins/FieldDay/lib/FieldDay/Util.pm
+++ b/plugins/FieldDay/lib/FieldDay/Util.pm
@@ -142,10 +142,12 @@ sub load_fields {
             $terms = $ctx->stash('fd:value_terms')
                 ? { %{$ctx->stash('fd:value_terms')}, 'key' => $field->name }
                 : app_value_terms(MT->instance, $field->name);
-            for my $value (FieldDay::Value->load($terms)) {
+            my $loadargs = { sort => 'id', direction => 'descend' };
+            for my $value (FieldDay::Value->load( $terms, $loadargs )) {
                 $values->{$field->name} ||= [];
                 my $i = ($value->instance && ($value->instance > 0)) ? ($value->instance - 1) : 0;
-                $values->{$field->name}->[$i] = $value;
+                $values->{$field->name}->[$i] = $value
+                    unless defined $values->{$field->name}->[$i];
             }
         }
     }


### PR DESCRIPTION
Grouped fields can sometimes create two conflicting values for the same field instance index (see below for example). What the fix does is ensure that the most recently created value for a particular group instance index is the one that is assigned and used. 

It does this by applying a descending sort order on ID and skipping re-initialization of a particular slot. Without an explicit load order, no particular order is guaranteed and hence while you usually see the record with the highest ID (i.e. the latest value) for that field group slot, that's not always the case.   

```
ID      blog_id    obj_type    obj_id  key             #   Value
2158    35         entry       309     document_label  1   Brochure
2159    35         entry       309     document_label  2   Sales Sheet
2160    35         entry       309     document_label  3   Persona M30 Sales Sheet
2161    35         entry       309     document_label  4   Card Design Guide
5244    35         entry       309     document_label  2   Persona M30 Sales Sheet
5245    35         entry       309     document_label  3   Card Design Guide
6012    35         entry       309     document_label  1    パンフレット
6013    35         entry       309     document_label  2    Persona M30 セールスシート
6014    35         entry       309     document_label  3    カード デザイン ガイド
```
